### PR TITLE
Add more options for get_filename_component

### DIFF
--- a/0001_get_filename_component/CMakeLists.txt
+++ b/0001_get_filename_component/CMakeLists.txt
@@ -1,9 +1,33 @@
 cmake_minimum_required(VERSION 3.8)
 
 project(get_filename_component C CXX)
+#ABSOLUTE  = Full path to file
 get_filename_component(test_file "test.cc" ABSOLUTE)
 message(STATUS "test_file:" ${test_file})
+#REALPATH  = Full path to existing file with symlinks resolved
+get_filename_component(test_file_REALPATH "test.cc" REALPATH)
+message(STATUS "test_file_REALPATH:" ${test_file_REALPATH})
+#PATH      = Legacy alias for DIRECTORY (use for CMake <= 2.8.11)
 get_filename_component(test_file_path "${test_file}" PATH)
 message(STATUS "test_file_path:" ${test_file_path})
+#NAME      = File name without directory
+get_filename_component(test_file_name "${test_file}" NAME)
+message(STATUS "test_file_name:" ${test_file_name})
+#DIRECTORY = Directory without file name
+get_filename_component(test_file_dir "${test_file}" DIRECTORY)
+message(STATUS "test_file_dir:" ${test_file_dir})
+#EXT       = File name longest extension (.b.c from d/a.b.c)
+get_filename_component(test_file_ext "${test_file}" EXT)
+message(STATUS "test_file_ext:" ${test_file_ext})
+#NAME_WE   = File name without directory or longest extension
+get_filename_component(test_file_name_we "${test_file}" NAME_WE)
+message(STATUS "test_file_name_we:" ${test_file_name_we})
+#LAST_EXT  = File name last extension (.c from d/a.b.c)
+get_filename_component(test_file_last_ext "${test_file}" LAST_EXT)
+message(STATUS "test_file_last_ext:" ${test_file_last_ext})
+#NAME_WLE  = File name without directory or last extension
+get_filename_component(test_file_name_wle "${test_file}" NAME_WLE)
+message(STATUS "test_file_name_wle:" ${test_file_name_wle})
+
 
 add_executable(get_filename_component test.cc)

--- a/0001_get_filename_component/result
+++ b/0001_get_filename_component/result
@@ -1,4 +1,3 @@
-jacui@jacui-HP-Zhan-86-Pro-G2-MT-Business-PC:~/workspace/cmake_git/cmake_learning/0001_get_filename_component/build$ cmake ..
 -- The C compiler identification is GNU 9.3.0
 -- The CXX compiler identification is GNU 9.3.0
 -- Check for working C compiler: /usr/bin/cc
@@ -14,7 +13,15 @@ jacui@jacui-HP-Zhan-86-Pro-G2-MT-Business-PC:~/workspace/cmake_git/cmake_learnin
 -- Detecting CXX compile features
 -- Detecting CXX compile features - done
 -- test_file:/home/jacui/workspace/cmake_git/cmake_learning/0001_get_filename_component/test.cc
+-- test_file_REALPATH:/home/jacui/workspace/cmake_git/cmake_learning/0001_get_filename_component/test.cc
 -- test_file_path:/home/jacui/workspace/cmake_git/cmake_learning/0001_get_filename_component
+-- test_file_name:test.cc
+-- test_file_dir:/home/jacui/workspace/cmake_git/cmake_learning/0001_get_filename_component
+-- test_file_ext:.cc
+-- test_file_name_we:test
+-- test_file_last_ext:.cc
+-- test_file_name_wle:test
 -- Configuring done
 -- Generating done
 -- Build files have been written to: /home/jacui/workspace/cmake_git/cmake_learning/0001_get_filename_component/build
+


### PR DESCRIPTION
DIRECTORY = Directory without file name
NAME      = File name without directory
EXT       = File name longest extension (.b.c from d/a.b.c)
NAME_WE   = File name without directory or longest extension
LAST_EXT  = File name last extension (.c from d/a.b.c)
NAME_WLE  = File name without directory or last extension
PATH      = Legacy alias for DIRECTORY (use for CMake <= 2.8.11)
ABSOLUTE  = Full path to file
REALPATH  = Full path to existing file with symlinks resolved